### PR TITLE
create apache_mysql.conf

### DIFF
--- a/Examples/apache_mysql.conf
+++ b/Examples/apache_mysql.conf
@@ -1,0 +1,47 @@
+<source>
+   @type tail
+   path /var/log/mysql/error.log
+   pos_file /var/log/td-agent/mysql_logs.pos
+   <parse>
+      @type regexp
+      expression /^(?<time>[0-9ZUTC+:.\- ]+) [^\s]+ \[(?<level>[^ ]*)\] (?<message>.*)/
+   </parse>
+   tag lm.mysql
+</source>
+
+<source>
+   @type tail
+   path /var/log/apache2/access.log
+   pos_file /var/log/td-agent/apche2.access_log.pos
+   tag lm.apache.access
+        <parse>
+           @type apache2
+        </parse>
+</source>
+
+<filter lm.apache.*>
+    @type record_transformer
+    <record>
+        hostname "#{Socket.gethostname}"
+        tag ${tag}
+        message ${record["host"]} ${record["user"]} ${record["method"]} ${record["path"]} ${record["code"]} ${record["size"]} ${record[$
+    </record>
+</filter>
+
+<filter lm.mysql>
+    @type record_transformer
+    <record>
+        hostname "#{Socket.gethostname}"
+        tag ${tag}
+    </record>
+</filter>
+
+<match lm.**>
+    @type lm
+    company_name YOUR_PORTAL_NAME
+    access_id "YOUR_API_ACCESS_ID"
+    access_key "YOUR_API_ACCESS_KEY"
+    flush_interval 1s
+    resource_mapping {"hostname": "system.sysname"}
+    debug true
+</match>


### PR DESCRIPTION
the apache2 plugin outputs fields host, user, etc. These need to be mapped to the "message" output for LogicMonitor plugin. Therefore there is a different <filter> for Apache than there is for <mysql>