### PR TITLE
DEV-81885 : Added library 'resolv-replace'

### DIFF
--- a/lib/fluent/plugin/out_lm.rb
+++ b/lib/fluent/plugin/out_lm.rb
@@ -9,7 +9,7 @@ require 'base64'
 require 'net/http'
 require 'net/https'
 require('zlib')
-
+require 'resolv-replace'
 
 module Fluent
   class LmOutput < BufferedOutput


### PR DESCRIPTION
Added library 'resolv-replace' for alpine 3.13 dns resolve issue which is required for alpine based fluentd daemonset image.