### PR TITLE
Allow additional record fields in ingest request

### DIFF
--- a/Examples/windows-iis-log.conf
+++ b/Examples/windows-iis-log.conf
@@ -1,0 +1,56 @@
+# Windows IIS log parsing.  This config uses the standard W3C format and the standard location for IIS logs.
+# It expects the log timestamp to be UTC.
+# Change the path below if you store your logs elsewhere.
+<source>
+  @type tail
+  tag lm.iis
+  path c:/inetpub/logs/logfiles/*/*
+  pos_file c:/opt/td-agent/iislog.pos
+  <parse>
+    @type regexp
+    expression /(?<time>\d{4}-\d{2}-\d{2} [\d:]+) (?<message>.+)/
+    time_format %Y-%m-%d %H:%M:%S
+	utc true
+  </parse>
+</source>
+
+#Filter IIS logs and parse the syntax
+<filter lm.iis>
+  @type parser
+  key_name message
+  remove_key_name_field false
+  reserve_data true
+  reserve_time true
+  <parse>
+    @type csv
+    delimiter ' '
+    keys hostname,req_method,req_uri,cs-uri-query,s_port,cs-username,c_ip,req_ua,req_referer,http_code,sc-substatus,sc-win32-status,time-taken
+    null_value_pattern -
+    null_empty_string true
+  </parse>
+</filter>
+
+# Filter events tagged with "lm.**" and add the hostname key to the record
+<filter lm.*>
+    @type record_transformer
+    <record>
+        hostname "#{Socket.gethostname}"
+        tag ${tag}
+    </record>
+</filter>
+
+# Match events tagged with "lm.**" and send them to LogicMonitor
+<match lm.**>
+    @type lm
+    resource_mapping {"hostname": "system.hostname"}
+    company_name "<lmaccount>"
+    access_id "<accessId>"
+    access_key "<accessKey>"
+      <buffer>
+        @type memory
+        flush_interval 1s
+        chunk_limit_size 5m
+      </buffer> 
+    debug false
+    compression gzip
+</match>

--- a/lib/fluent/plugin/out_lm.rb
+++ b/lib/fluent/plugin/out_lm.rb
@@ -26,6 +26,8 @@ module Fluent
     config_param :resource_mapping,  :hash, :default => {"host": "system.hostname", "hostname": "system.hostname"}
 
     config_param :debug,  :bool, :default => false
+
+    config_param :include_metadata,  :bool, :default => false
 		
     config_param :force_encoding,  :string, :default => ""
 
@@ -100,14 +102,21 @@ module Fluent
         lm_event["timestamp"] = Time.at(time).utc.to_datetime.rfc3339
       end
 
-      #Add any additonal record keys as additional metadata
-      record.each do |key, value|
-        if key != "timestamp" || key != "_lm.resourceId"
-            lm_event["#{key}"] = value
-
-            if @force_encoding != ""
-                lm_event["#{key}"] = lm_event["#{key}"].force_encoding(@force_encoding).encode("UTF-8")
-            end
+      if @include_metadata
+        record.each do |key, value|
+          if key != "timestamp" || key != "_lm.resourceId"
+              lm_event["#{key}"] = value
+  
+              if @force_encoding != ""
+                  lm_event["#{key}"] = lm_event["#{key}"].force_encoding(@force_encoding).encode("UTF-8")
+              end
+          end
+        end
+      else
+        lm_event["message"] = record["message"]
+      
+        if @force_encoding != ""
+          lm_event["message"] = lm_event["message"].force_encoding(@force_encoding).encode("UTF-8")
         end
       end
 

--- a/lib/fluent/plugin/out_lm.rb
+++ b/lib/fluent/plugin/out_lm.rb
@@ -79,11 +79,6 @@ module Fluent
     def process_record(tag, time, record)
       resource_map = {}
       lm_event = {}
-      lm_event["message"] = record["message"]
-      
-      if @force_encoding != ""
-        lm_event["message"] = lm_event["message"].force_encoding(@force_encoding).encode("UTF-8")
-      end
 
       if record["_lm.resourceId"] == nil
           @resource_mapping.each do |key, value|
@@ -103,6 +98,17 @@ module Fluent
         lm_event["timestamp"] = record["timestamp"]
       else
         lm_event["timestamp"] = Time.at(time).utc.to_datetime.rfc3339
+      end
+
+      #Add any additonal record keys as additional metadata
+      record.each do |key, value|
+        if key != "timestamp" || key != "_lm.resourceId"
+            lm_event["#{key}"] = value
+
+            if @force_encoding != ""
+                lm_event["#{key}"] = lm_event["#{key}"].force_encoding(@force_encoding).encode("UTF-8")
+            end
+        end
       end
 
       return lm_event

--- a/test/plugin/test_out_lm.rb
+++ b/test/plugin/test_out_lm.rb
@@ -63,8 +63,8 @@ class FluentLMTest < Test::Unit::TestCase
   end
 
   sub_test_case "force_encoding" do
-      test "force_encoding passed as true, should convert invalid utf-8 characters" do
-        plugin = create_driver(%[
+    test "force_encoding passed as true, should convert invalid utf-8 characters" do
+      plugin = create_driver(%[
           resource_mapping {"a.b": "lm_property"} 
           force_encoding ISO-8859-1
       ]).instance
@@ -78,29 +78,74 @@ class FluentLMTest < Test::Unit::TestCase
       assert_equal "LogicMonitor®", event["message"]
     end
   end
+  
 
   sub_test_case "time" do
     test "timestamp passed in the record, it should use that" do
       plugin = create_driver(%[
         resource_mapping {"a.b": "lm_property"} 
-    ]).instance
+      ]).instance
 
-    tag = "lm.test"
-    time = Time.parse("2020-08-23T00:53:15+00:00").to_i
-    record = {"message" => "Hello from test",  "timestamp" => "2020-10-30T00:29:08.629701504Z" ,"a" => { "b" => "lm_property_value" } }
-  
-    result = plugin.process_record(tag, time, record)
-      
-    expected = {
-        "message" => "Hello from test",
-        "_lm.resourceId" => {
-            "lm_property" => "lm_property_value"
-        },
-        "timestamp" => "2020-10-30T00:29:08.629701504Z"
-    }
+      tag = "lm.test"
+      time = Time.parse("2020-08-23T00:53:15+00:00").to_i
+      record = {"message" => "Hello from test",  "timestamp" => "2020-10-30T00:29:08.629701504Z" ,"a" => { "b" => "lm_property_value" } }
+    
+      result = plugin.process_record(tag, time, record)
+        
+      expected = {
+          "message" => "Hello from test",
+          "_lm.resourceId" => {
+              "lm_property" => "lm_property_value"
+          },
+          "timestamp" => "2020-10-30T00:29:08.629701504Z"
+      }
 
-    assert_equal expected, result
+      assert_equal expected, result
+    end
   end
-end
 
+  sub_test_case "include_metadata" do
+    test "include_metadata passed as true, it should include other record items as additional metadata" do
+      plugin = create_driver(%[
+        resource_mapping {"a.b": "lm_property"} 
+        include_metadata true
+      ]).instance
+
+      tag = "lm.test"
+      time = Time.parse("2020-08-23T00:53:15+00:00").to_i
+      record = {"message" => "Hello from test",  "timestamp" => "2020-10-30T00:29:08.629701504Z", "tag" => "lm.test" , "_lm.resourceId" => { "lm_property": "lm_property_value" } }
+
+      result = plugin.process_record(tag, time, record)
+        
+      expected = {
+          "message" => "Hello from test",
+          "_lm.resourceId" => record["_lm.resourceId"],
+          "timestamp" => "2020-10-30T00:29:08.629701504Z",
+          "tag" => "lm.test"
+      }
+
+      assert_equal expected, result
+    end
+
+    test "include_metadata passed as false, it should exclude other record items as additional metadata" do
+      plugin = create_driver(%[
+        resource_mapping {"a.b": "lm_property"} 
+        include_metadata false
+      ]).instance
+
+      tag = "lm.test"
+      time = Time.parse("2020-08-23T00:53:15+00:00").to_i
+      record = {"message" => "Hello from test",  "timestamp" => "2020-10-30T00:29:08.629701504Z", "tag" => "lm.test" , "_lm.resourceId" => { "lm_property": "lm_property_value" } }
+
+      result = plugin.process_record(tag, time, record)
+        
+      expected = {
+          "message" => "Hello from test",
+          "_lm.resourceId" => record["_lm.resourceId"],
+          "timestamp" => "2020-10-30T00:29:08.629701504Z"
+      }
+
+      assert_equal expected, result
+    end
+  end
 end


### PR DESCRIPTION
Added the ability to send additional record fields as metadata in the ingest request to LM Logs

![image](https://user-images.githubusercontent.com/42367049/133515265-71ab9893-0001-4582-b43d-21506da43fb4.png)
