### PR TITLE
Add Request Body to Debug Log Output

### DIFF
--- a/lib/fluent/plugin/out_lm.rb
+++ b/lib/fluent/plugin/out_lm.rb
@@ -194,7 +194,9 @@ module Fluent
       resp = http.request(request)
       if @debug || (!resp.kind_of? Net::HTTPSuccess)
         log.info "Status code:#{resp.code} Request Id:#{resp.header['x-request-id']}"
-	log.info "Request body:#{resp.body}"
+        if (resp.kind_of? Net::HTTPMultiStatus)
+	        log.info "Partial messages accepted by Logicmonitor. This might have been caused by a failure in resource mapping or logs older than 3 hrs."
+        end
       end
     end
 

--- a/lib/fluent/plugin/out_lm.rb
+++ b/lib/fluent/plugin/out_lm.rb
@@ -194,6 +194,7 @@ module Fluent
       resp = http.request(request)
       if @debug || (!resp.kind_of? Net::HTTPSuccess)
         log.info "Status code:#{resp.code} Request Id:#{resp.header['x-request-id']}"
+	log.info "Request body:#{resp.body}"
       end
     end
 


### PR DESCRIPTION
Problem:

When trying to troubleshoot a `207 status code`, need additional Request Body data to view the `error`.

Solution:

Added additional `log.info` line to `@debug` to produce the Request Body with errors.