### PR TITLE
DEV-132845 Use persistent http client for sending logs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN mkdir /logicmonitor
 COPY ./ logicmonitor
 WORKDIR /logicmonitor
 RUN gem install fluentd
+RUN gem install net-http-persistent
 RUN ruby test/stable_performance_result_generator.rb
 RUN rake
 RUN bundle install

--- a/fluent-plugin-lm-logs.gemspec
+++ b/fluent-plugin-lm-logs.gemspec
@@ -2,10 +2,15 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at LogicMonitor (https://www.logicmonitor.com).
 # Copyright 2020 LogicMonitor, Inc.
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require "fluent/plugin/version.rb"
+
 
 Gem::Specification.new do |spec|
   spec.name                           = "fluent-plugin-lm-logs"
-  spec.version                        = '1.0.4'
+  spec.version                        = LmLogsFluentPlugin::VERSION
   spec.authors                        = ["LogicMonitor"]
   spec.email                          = "rubygems@logicmonitor.com"
   spec.summary                        = "LogicMonitor logs fluentd output plugin"
@@ -16,9 +21,10 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"]    = "https://github.com/logicmonitor/lm-logs-fluentd"
   spec.metadata["documentation_uri"]  = "https://www.rubydoc.info/gems/lm-logs-fluentd"
 
-  spec.files         = [".gitignore", "Gemfile", "LICENSE", "README.md", "Rakefile", "fluent-plugin-lm-logs.gemspec", "lib/fluent/plugin/out_lm.rb"]
+  spec.files         = [".gitignore", "Gemfile", "LICENSE", "README.md", "Rakefile", "fluent-plugin-lm-logs.gemspec", "lib/fluent/plugin/version.rb", "lib/fluent/plugin/out_lm.rb"]
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency "fluentd", [">= 1", "< 2"]
+  spec.add_runtime_dependency "net-http-persistent", '~> 4.0.1'
 end

--- a/lib/fluent/plugin/version.rb
+++ b/lib/fluent/plugin/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module LmLogsFluentPlugin
+    VERSION = '1.0.5'
+end


### PR DESCRIPTION
Use persistent http client for sending logs.
Add plugin version to User-Agent header.