### PR TITLE
Excluded performance tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,6 @@ require "rake/testtask"
 task default: "test"
 
 Rake::TestTask.new do |task|
- task.pattern = "test/plugin/*.rb"
+ task.libs << "test"
+ task.test_files = Dir.glob('test/plugin/*.rb') - ['test/plugin/test_performance.rb']
 end

--- a/lib/fluent/plugin/version.rb
+++ b/lib/fluent/plugin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LmLogsFluentPlugin
-    VERSION = '1.2.1'
+    VERSION = '1.2.2'
 end


### PR DESCRIPTION
Excluded performance tests in Rakefile which were blocking release fluent-plugin-lm-logs