### PR TITLE
Lm logs fluentd plugin should not have the account domain hard coded

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Create a custom `fluent.conf` or edit the existing one to specify which logs sho
     @type lm
     resource_mapping {"<event_key>": "<lm_property>"}
     company_name <lm_company_name>
+    company_domain <lm_company_domain>
 	access_id <lm_access_id>
     access_key <lm_access_key>
       <buffer>
@@ -63,6 +64,7 @@ See the [LogicMonitor Helm repository](https://github.com/logicmonitor/k8s-helm-
 | Property | Description |
 | --- | --- |
 | `company_name` | LogicMonitor account name. |
+| `company_domain` | LogicMonitor account domain. For eg. for url test.logicmonitor.com, company_domain is logicmonitor. Default is `logicmonitor`. |
 | `resource_mapping` | The mapping that defines the source of the log event to the LM resource. In this case, the `<event_key>` in the incoming event is mapped to the value of `<lm_property>`.|
 | `access_id` | LM API Token access ID. |
 | `access_key` | LM API Token access key. |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See the [LogicMonitor Helm repository](https://github.com/logicmonitor/k8s-helm-
 | Property | Description |
 | --- | --- |
 | `company_name` | LogicMonitor account name. |
-| `company_domain` | LogicMonitor account domain. For eg. for url test.logicmonitor.com, company_domain is logicmonitor. Default is `logicmonitor`. |
+| `company_domain` | LogicMonitor account domain. For eg. for url test.logicmonitor.com, company_domain is logicmonitor.com . Default is `logicmonitor.com`. |
 | `resource_mapping` | The mapping that defines the source of the log event to the LM resource. In this case, the `<event_key>` in the incoming event is mapped to the value of `<lm_property>`.|
 | `access_id` | LM API Token access ID. |
 | `access_key` | LM API Token access key. |

--- a/lib/fluent/plugin/out_lm.rb
+++ b/lib/fluent/plugin/out_lm.rb
@@ -49,7 +49,7 @@ module Fluent
 
     config_param :http_proxy,   :string, :default => nil
 
-    config_param :company_domain ,  :string, :default => "logicmonitor"
+    config_param :company_domain ,  :string, :default => "logicmonitor.com"
 
     # Use bearer token for auth.
     config_param :bearer_token, :string, :default => nil, secret: true
@@ -79,7 +79,7 @@ module Fluent
       @http_client = Net::HTTP::Persistent.new name: "fluent-plugin-lm-logs", proxy: proxy_uri
       @http_client.override_headers["Content-Type"] = "application/json"
       @http_client.override_headers["User-Agent"] = log_source + "/" + LmLogsFluentPlugin::VERSION
-      @url = "https://#{@company_name}.#{@company_domain}.com/rest/log/ingest"
+      @url = "https://#{@company_name}.#{@company_domain}/rest/log/ingest"
       @uri = URI.parse(@url)
     end
 

--- a/lib/fluent/plugin/out_lm.rb
+++ b/lib/fluent/plugin/out_lm.rb
@@ -49,6 +49,8 @@ module Fluent
 
     config_param :http_proxy,   :string, :default => nil
 
+    config_param :company_domain ,  :string, :default => "logicmonitor"
+
     # Use bearer token for auth.
     config_param :bearer_token, :string, :default => nil, secret: true
 
@@ -77,7 +79,7 @@ module Fluent
       @http_client = Net::HTTP::Persistent.new name: "fluent-plugin-lm-logs", proxy: proxy_uri
       @http_client.override_headers["Content-Type"] = "application/json"
       @http_client.override_headers["User-Agent"] = log_source + "/" + LmLogsFluentPlugin::VERSION
-      @url = "https://#{@company_name}.logicmonitor.com/rest/log/ingest"
+      @url = "https://#{@company_name}.#{@company_domain}.com/rest/log/ingest"
       @uri = URI.parse(@url)
     end
 

--- a/lib/fluent/plugin/version.rb
+++ b/lib/fluent/plugin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LmLogsFluentPlugin
-    VERSION = '1.2.2'
+    VERSION = '1.2.3'
 end


### PR DESCRIPTION
Allowing configurable `company_domain` for users with logicmonitor domain different from logicmonitor.com
Version - 1.2.3