### PR TITLE
feat/add-fluent:  Add fluent-plugin-parser-cri to Debian and AL2023 Fluentd images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     gem install fluent-plugin-systemd -v 1.1.1 && \
     gem install fluent-plugin-lm-logs -v 1.2.8 && \
     gem install fluent-plugin-multi-format-parser -v 1.0.0 && \
+    gem install fluent-plugin-parser-cri -v 0.1.1 && \
     apt-get purge -y \
       build-essential \
       libsystemd-dev \

--- a/docker/Dockerfile.al2023
+++ b/docker/Dockerfile.al2023
@@ -23,7 +23,8 @@ RUN gem install --no-document --install-dir "$GEM_HOME" --bindir /opt/fluent/bin
       fluent-plugin-systemd:1.1.1 \
       fluent-plugin-concat:2.5.0 \
       fluent-plugin-lm-logs:1.2.8 \
-      fluent-plugin-multi-format-parser:1.0.0 && \
+      fluent-plugin-multi-format-parser:1.0.0 \
+      fluent-plugin-parser-cri:0.1.1 && \
     rm -rf "$GEM_HOME"/cache/*
 
 # Strip native .so + trim headers/archives to save space


### PR DESCRIPTION

Enables FLUENT_CONTAINER_TAIL_PARSER_TYPE=cri for Kubernetes CRI log lines.
DEVTS background: https://jira.cloudatl.logicmonitor.net/browse/DEVTS-23863
lm-logs on Argus uses lm-logs-k8s-fluentd:1.0.0-al2023. That image did not bundle fluent-plugin-parser-cri, so Fluentd had no cri parser. Container log files stayed in raw CRI line form (timestamp, stdout/stderr, F/P, then payload). Setting FLUENT_CONTAINER_TAIL_PARSER_TYPE=cri failed at startup with Unknown parser plugin 'cri'. Multiline / JSON-style handling degraded because the prefix was never stripped.
 DEV-testing details : https://confluence.cloudatl.logicmonitor.net/wiki/x/TQGPGg


